### PR TITLE
Screenspace error corrector

### DIFF
--- a/Apps/CesiumViewer/CesiumViewer.js
+++ b/Apps/CesiumViewer/CesiumViewer.js
@@ -7,6 +7,7 @@ define([
         'Cesium/Core/Math',
         'Cesium/Core/objectToQuery',
         'Cesium/Core/queryToObject',
+        'Cesium/Core/CesiumTerrainProvider',
         'Cesium/DataSources/CzmlDataSource',
         'Cesium/DataSources/GeoJsonDataSource',
         'Cesium/DataSources/KmlDataSource',
@@ -23,6 +24,7 @@ define([
         CesiumMath,
         objectToQuery,
         queryToObject,
+        CesiumTerrainProvider,
         CzmlDataSource,
         GeoJsonDataSource,
         KmlDataSource,
@@ -59,7 +61,13 @@ define([
         viewer = new Viewer('cesiumContainer', {
             imageryProvider : imageryProvider,
             baseLayerPicker : !defined(imageryProvider),
-            scene3DOnly : endUserOptions.scene3DOnly
+            scene3DOnly : endUserOptions.scene3DOnly,
+            baseLayerPicker : false,
+            terrainProvider : endUserOptions.terrain ?
+            new CesiumTerrainProvider({
+                  url : '//assets.agi.com/stk-terrain/world',
+                requestVertexNormals : false
+            }) : undefined
         });
     } catch (exception) {
         loadingIndicator.style.display = 'none';
@@ -71,6 +79,9 @@ define([
         return;
     }
 
+    window.viewer = viewer;
+    viewer.scene.globe._surface.debug = true;
+    viewer.scene.globe._surface._debug.enableDebugOutput = true;
     viewer.extend(viewerDragDropMixin);
     if (endUserOptions.inspector) {
         viewer.extend(viewerCesiumInspectorMixin);

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -70,6 +70,7 @@ define([
         }
         //>>includeEnd('debug');
 
+        this._sseCorrector = options.sseCorrector;
         this._tileProvider = options.tileProvider;
         this._tileProvider.quadtree = this;
 
@@ -379,21 +380,8 @@ define([
         }
 
         // Compute camera height once
-        cameraHeight = frameState.camera.positionCartographic.height;
-
-        if (pickglobe) {
-          var scene = frameState.camera._scene;
-          var canvas = scene.canvas;
-          var pixelHeight = pickposition * canvas.clientHeight;
-          var pixel = new Cartesian2(canvas.clientWidth / 2, pixelHeight);
-          var ray = scene.camera.getPickRay(pixel);
-          var target = scene.globe.pick(ray, scene);
-          // Could also take bottom in the absence of result
-          // then take cameraHeight
-          if (target) {
-            var distance = Cartesian3.distance(frameState.camera.position, target);
-            cameraHeight = Math.max(cameraHeight, distance);
-          }
+        if (defined(primitive.sseCorrector)) {
+          primitive.sseCorrector.newFrameState(frameState);
         }
 
         // Traverse the tiles in breadth-first order.
@@ -453,30 +441,6 @@ define([
         }
     }
 
-    var params = {};
-    location.search.substr(1).split("&").reduce(function(previous, current) {
-      var splitted = current.split("=");
-      if (splitted.length === 2) {
-        params[splitted[0]] = splitted[1];
-      } else {
-        params[splitted[0]] = true;
-      }
-    });
-
-    var mindist = parseInt(defaultValue(params['mindist'], '5000'), 10);
-    var maxdist = parseInt(defaultValue(params['maxdist'], '10000'), 10);
-    var mincamfactor = parseFloat(defaultValue(params['mincamfactor'], '0.9'));
-    var maxcamfactor = parseFloat(defaultValue(params['maxcamfactor'], '1.2'));
-    // Max height to apply optmization
-    var maxheight = parseInt(defaultValue(params['maxheight'], '0'), 10);
-    var allowtilelevels = parseInt(defaultValue(params['allowtilelevels'], '0'), 10);
-    var pickglobe = !params['nopickglobe'];
-    var pickposition = parseInt(defaultValue(params['pickposition'], '0.6666'), 10);
-    var shouldCut = !params['nocut'];
-    var noheight = !!params['noheight'];
-    var maxerrorfactor = parseFloat(defaultValue(params['maxerrorfactor'], '0.25'));
-    var cameraHeight;
-
     function screenSpaceError(primitive, frameState, tile) {
         if (frameState.mode === SceneMode.SCENE2D) {
             return screenSpaceError2D(primitive, frameState, tile);
@@ -494,35 +458,11 @@ define([
         var fovy = frustum.fovy;
 
         // PERFORMANCE_IDEA: factor out stuff that's constant across tiles.
-        var original = (maxGeometricError * height) / (2 * distance * Math.tan(0.5 * fovy));
-
-        if (!shouldCut || (maxheight && (cameraHeight > maxheight)) ||
-            (allowtilelevels && (tile._level <= allowtilelevels))) {
-          return original;
+        var error = (maxGeometricError * height) / (2 * distance * Math.tan(0.5 * fovy));
+        if (defined(primitive.sseCorrector)) {
+          error = primitive.sseCorrector.correct(frameState, tile, distance, error);
         }
-
-        // TODO: should be optimized out
-        var min = mindist;
-        var max = maxdist;
-        if (!noheight) {
-          min = Math.min(mindist, mincamfactor * cameraHeight);
-          max = Math.max(maxdist, maxcamfactor * cameraHeight);
-        }
-
-        if (distance < max) {
-          if (distance < min || min === max) {
-            return original;
-          } else {
-            // 1 = a * min + b
-            // maxerrorfactor = a * max + b
-            var a = (1 - maxerrorfactor) / (min - max);
-            var b = 1 - a * min;
-            var linearFactor = a * distance + b;
-            return linearFactor * original;
-          }
-        } else {
-          return maxerrorfactor * original;
-        }
+        return error;
     }
 
     function screenSpaceError2D(primitive, frameState, tile) {


### PR DESCRIPTION
Linearly decrease computed tile error of distant tiles according to 3 zones.
-    error \* 1 when distance < mindist;
-    linear(error) when mindist < distance < maxdist;
-    error \* maxerrorfactor

This is testable and an example of use is in the viewer.

Tweakable parameters are:
-    `mindist`, the minimum distance before applying correction default: 5000 units: kilometers
-    `maxdist`, the maximum distance for applying linear correction default: 10000 units: kilometers
-    `maxerrorfactor`, the factor to apply after maxdist default: 0.25 units: none
-    `nocut`, to disable optimization
-    `noheight`, to disable using camera height to adjust mindist and maxdist
-    `nopickglobe`, to disable using the distance to a point on the screen
-    `pickposition`, the canvas height ratio for defining the position where to pick the globe default: 0.6666 (2 third of the screen starting from the top) units: none
-    `maxheight:` camera height starting from which to disable the optimization default: 0 (optimization always enabled) units: kilometers
-    `mincamfactor`, a factor to apply to mindist when using picking default: 0.9
-    `maxcamfactor`, a factor to apply to maxdist when using picking default: 1.2

These distances are automatically corrected according to the camera height:
even when the camera is above maxdistance, correct terrain will be shown.

Camera factor is used like this:

```
if (!noheight) {
  min = Math.min(mindist, mincamfactor * cameraHeight);
  max = Math.max(maxdist, maxcamfactor * cameraHeight);
}
```
