### PR TITLE
Test the availability of loadingImagery instead of the tile itself

### DIFF
--- a/Source/Scene/TileImagery.js
+++ b/Source/Scene/TileImagery.js
@@ -49,7 +49,7 @@ define([
         var imageryLayer = loadingImagery.imageryLayer;
         var imageryProvider = loadingImagery.imageryLayer.imageryProvider;
         if (!defined(imageryProvider.getTileDataAvailable) ||
-                imageryProvider.getTileDataAvailable(tile.x, tile.y, tile.level)) {
+                imageryProvider.getTileDataAvailable(loadingImagery.x, loadingImagery.y, loadingImagery.level)) {
             loadingImagery.processStateMachine(context, commandList);
         } else {
             loadingImagery.state = ImageryState.INVALID;


### PR DESCRIPTION
Since a not available tile  (outside the extent of the terrain or outside range define in the layer.json) can try to download an imagery which has not the same coordinates because the imagery overlaps this tile. That makes more sense to test the avialability of the imagery and not the tile.
